### PR TITLE
Switch back to direct BOLD URLs rather than DOIs

### DIFF
--- a/web/src/components/data/BINSummaryTable.vue
+++ b/web/src/components/data/BINSummaryTable.vue
@@ -18,7 +18,7 @@
           class="text-left bg-slate-100 even:bg-slate-200"
         >
           <td class="py-2 pl-2">
-            <a target="_blank" :href="getBINDOI(binSummary)">
+            <a target="_blank" :href="getBINLink(binSummary)">
               {{ binSummary.bin }}
             </a>
           </td>
@@ -55,8 +55,8 @@ const headers = [
 
 const { binSummaries } = defineProps(['binSummaries']);
 
-function getBINDOI(binSummary) {
-  return `https://doi.org/10.5883/${binSummary.bin}`;
+function getBINLink(binSummary) {
+  return `https://portal.boldsystems.org/bin/${binSummary.bin}`;
 }
 </script>
 


### PR DESCRIPTION
Not sure why this doesn't work as I assumed BOLD had created DOIs for all their BINs. Perhaps it's still ongoing and there are some they haven't generated yet? Not sure, but we'll just go back to using a direct link to their Portal instead.

Closes: #25